### PR TITLE
Splitting the RTS into a Fiber runtime and an IO interpreter

### DIFF
--- a/effect/jvm/src/main/scala/scalaz/effect/FutureInterpreterExample.scala
+++ b/effect/jvm/src/main/scala/scalaz/effect/FutureInterpreterExample.scala
@@ -1,0 +1,30 @@
+package scalaz.effect
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object FutureInterpreterExample {
+
+  def main(args: Array[String]): Unit = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val rts = new DefaultRTS
+    val iOInterpreter = FutureIOInterpreter(rts)
+
+    val program = for {
+      _ <- IO.sync(println("first"))
+      _ <- IO.sync(println("second"))
+      _ <- IO.sync(println("third"))
+    } yield 3
+
+    Await.ready(
+      iOInterpreter.tryUnsafePerformIO(program).andThen {
+        case r => println(s"iOInterpreter finished with a $r")
+      },
+      1.second
+    )
+    rts.shutdown()
+    ()
+  }
+
+}


### PR DESCRIPTION
Doing so could allow different interpretation strategies (blocking, asynchronous). In particular, it would be easy to interpret `IO`s into `Future`s. 

This PR is just a proof of concept. What do you think of this approach?