### PR TITLE
Attempting a bracket catches errors twice

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val effect       = crossProject.in(file("effect"))
   .settings(
     libraryDependencies ++=
       Seq ( "org.specs2" %%% "specs2-core"           % "4.0.0" % "test"
+          , "org.specs2" %%% "specs2-scalacheck"     % "4.0.0" % "test"
           , "org.specs2" %%% "specs2-matcher-extra"  % "4.0.0" % "test"),
       scalacOptions in Test ++= Seq("-Yrangepos"))
   .dependsOn( base )

--- a/effect/jvm/src/main/scala/scalaz/effect/RTS.scala
+++ b/effect/jvm/src/main/scala/scalaz/effect/RTS.scala
@@ -472,12 +472,12 @@ private object RTS {
 
                         if (curIo == null) {
                           eval   = false
-                          result = \/-(value)
+                          result = value
                         }
                       } else {
                         // Must run finalizer first:
                         val reported  = dispatchErrors(finalizer)
-                        val completer = IO.now[Any](\/-(value))
+                        val completer = IO.now[Any](value)
 
                         // Do not interrupt finalization:
                         this.noInterrupt += 1
@@ -701,10 +701,10 @@ private object RTS {
 
           if (finalizer == null) {
             if (stack.isEmpty()) done(value.asInstanceOf[Try[A]])
-            else continueWithValue(value, \/-(value))
+            else continueWithValue(value, value)
           } else {
             val reported  = dispatchErrors(finalizer)
-            val completer = if (stack.isEmpty()) IO.fail(t) else IO.now(\/-(value))
+            val completer = if (stack.isEmpty()) IO.fail(t) else IO.now(value)
 
             // Do not interrupt finalization:
             this.noInterrupt += 1

--- a/effect/jvm/src/test/scala/scalaz/effect/IOTest.scala
+++ b/effect/jvm/src/test/scala/scalaz/effect/IOTest.scala
@@ -1,0 +1,155 @@
+package scalaz.effect
+
+import org.scalacheck.{Arbitrary, Gen, Prop}
+import org.specs2.{ScalaCheck, Specification}
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.specification.AroundTimeout
+
+import scalaz.data.Disjunction.{-\/, \/-}
+
+class IOTest(implicit ee: ExecutionEnv) extends Specification
+  with AroundTimeout
+  with ScalaCheck
+  with RTS {
+
+  override val defaultHandler = t => IO.unit
+
+  def is = {
+    s2"""
+    IO properties
+      success is independent of construction                     $testSuccessfulIOConstruction
+      failure is independent of construction                     $testFailedIOConstruction
+      absolving attempts is identity                             $testAbsolveAttemptIsIdentity
+    """
+  }
+
+  def testSuccessfulIOConstruction: Prop = {
+    Prop.forAll(generators.primitives.successfulIO[Unit], generators.primitives.successfulIO[Unit]) {
+      (a, b) => {
+        tryUnsafePerformIO(a) must_=== tryUnsafePerformIO(b)
+      }
+    }
+  }
+
+  def testFailedIOConstruction: Prop = {
+    Prop.forAll { (t: Throwable) =>
+      implicit val arbitraryT = Arbitrary(Gen.const(t))
+      Prop.forAll(generators.primitives.failedIO[Unit], generators.primitives.failedIO[Unit]) {
+        (a, b) => {
+          tryUnsafePerformIO(a) must_=== tryUnsafePerformIO(b)
+        }
+      }
+    }
+
+  }
+
+  def testAbsolveAttemptIsIdentity: Prop = {
+    Prop.forAll(generators.io[Unit]) { io =>
+      tryUnsafePerformIO(IO.absolve(io.attempt)) must_=== tryUnsafePerformIO(io)
+    }
+  }
+
+  object generators {
+
+    object primitives {
+
+      // Pure generators
+
+      def now[A](implicit arbitrary: Arbitrary[A]): Gen[IO[A]] = {
+        arbitrary.arbitrary.map(IO.now).label("now")
+      }
+
+      def point[A](implicit arbitrary: Arbitrary[A]): Gen[IO[A]] = {
+        arbitrary.arbitrary.map(IO.point(_)).label("point")
+      }
+
+      def fail[A](implicit arbitrary: Arbitrary[Throwable]): Gen[IO[A]] = {
+        arbitrary.arbitrary.map[IO[A]](IO.fail).label("fail")
+      }
+
+      // Synchronous generators
+
+      def successfulSync[A](implicit arbitrary: Arbitrary[A]): Gen[IO[A]] = {
+        arbitrary.arbitrary.map(IO.sync(_)).label("successfulSync")
+      }
+
+      def failedSync[A](implicit arbitrary: Arbitrary[Throwable]): Gen[IO[A]] = {
+        arbitrary.arbitrary.map[IO[A]](t => IO.sync(throw t)).label("failedSync")
+      }
+
+      // Asynchronous generators
+
+      def successfulAsyncNow[A](implicit arbitrary: Arbitrary[A]): Gen[IO[A]] = {
+        arbitrary.arbitrary.map { a =>
+          IO.async0[A] { _ =>
+            AsyncReturn.now(a)
+          }
+        }.label("successfulAsyncNow")
+      }
+
+      def successfulAsyncLater[A](implicit arbitrary: Arbitrary[A]): Gen[IO[A]] = {
+        arbitrary.arbitrary.map[IO[A]] { a =>
+          IO.async0 { callback =>
+            callback(\/-(a))
+            AsyncReturn.later
+          }
+        }.label("successfulAsyncLater")
+      }
+
+      def failedAsync[A](implicit arbitrary: Arbitrary[Throwable]): Gen[IO[A]] = {
+        arbitrary.arbitrary.map[IO[A]] { t =>
+          IO.async0 { callback =>
+            callback(-\/(t))
+            AsyncReturn.later
+          }
+        }.label("failedAsync")
+      }
+
+      // Wrapping up
+
+      def successfulIO[A](implicit a: Arbitrary[A]): Gen[IO[A]] = {
+        Gen.oneOf(
+          now[A],
+          point[A],
+          successfulSync[A],
+          successfulAsyncNow[A],
+          successfulAsyncLater[A],
+        )
+      }
+
+      def failedIO[A](implicit t: Arbitrary[Throwable]): Gen[IO[A]] = {
+        Gen.oneOf(
+          fail[A],
+          failedSync[A],
+          failedAsync[A]
+        )
+      }
+    }
+
+    object composites {
+      def bracket[A](implicit a: Arbitrary[A], t: Arbitrary[Throwable]): Gen[IO[A]] = (for {
+        acquire <- io[A]
+        release <- io[Unit]
+        use <- io[A]
+      } yield {
+        acquire.bracket[A](_ => release)(_ => use)
+      }).label("bracket")
+    }
+
+    // wrapping up
+
+    import composites._
+    import primitives._
+
+    def io[A](implicit a: Arbitrary[A], t: Arbitrary[Throwable]): Gen[IO[A]] = {
+      Gen.lzy(Gen.frequency(
+        5 -> successfulIO[A],
+        3 -> failedIO[A],
+        1 -> bracket[A]
+      ))
+    }
+
+  }
+
+
+}


### PR DESCRIPTION
Attempting after a failed bracket wraps the error into an additional `\/-` and will fail at runtime (res3, res4, res5) .

```scala
import scalaz.effect.{IO, RTS}
val rts = new RTS {}
import rts.tryUnsafePerformIO

val ok = IO.sync(())
val ko = IO.fail[Unit](new Exception())

tryUnsafePerformIO(
  ok.bracket_(ok)(ko)
)
// res0: Throwable \/ Unit = -\/(java.lang.Exception)

tryUnsafePerformIO(
  ko.bracket_(ok)(ok)
)
// res1: Throwable \/ Unit = -\/(java.lang.Exception)

tryUnsafePerformIO(
  ok.bracket_(ko)(ok)
)
// res2: Throwable \/ Unit = -\/(java.lang.Exception)

tryUnsafePerformIO(
  IO.absolve(
    ok.bracket_(ok)(ko).attempt
  )
)
// res3: Throwable \/ Unit = \/-(-\/(java.lang.Exception))

tryUnsafePerformIO(
  IO.absolve(
    ko.bracket_(ok)(ok).attempt
  )
)

// res4: Throwable \/ Unit = \/-(-\/(java.lang.Exception))

tryUnsafePerformIO(
  IO.absolve(
    ok.bracket_(ko)(ok).attempt
  )
)
// res5: Throwable \/ Unit = \/-(-\/(java.lang.Exception))
```

I have fixed several places in RTS where such nesting takes place, and these fixes are sufficient to make the new tests pass. 

Please check it, however, as I don't have enough of a big picture to be sure it doesn't break something else.